### PR TITLE
Change options controller to not return 404 when the list contains zero elements

### DIFF
--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.27.0-alpha.1</Version>
-    <AssemblyVersion>4.27.0.0</AssemblyVersion>
+    <Version>4.28.0-alpha.1</Version>
+    <AssemblyVersion>4.28.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>
     <Description>

--- a/src/Altinn.App.Api/Controllers/OptionsController.cs
+++ b/src/Altinn.App.Api/Controllers/OptionsController.cs
@@ -52,7 +52,7 @@ namespace Altinn.App.Api.Controllers
             appOptions = await _altinnApp.GetOptions(optionsId, appOptions);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            if (appOptions.Options == null || appOptions.Options.Count == 0)
+            if (appOptions.Options == null)
             {
                 return NotFound();
             }
@@ -89,7 +89,9 @@ namespace Altinn.App.Api.Controllers
 
             AppOptions appOptions = await _appOptionsService.GetOptionsAsync(instanceIdentifier, optionsId, language, queryParams);
 
-            if (appOptions.Options == null || appOptions.Options.Count == 0)
+            // Only return NotFound if we can't find an options provider.
+            // If we find the options provider, but it doesnt' have values, return empty list.
+            if (appOptions.Options == null)
             {
                 return NotFound();
             }

--- a/src/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.27.0-alpha.1</Version>
-    <AssemblyVersion>4.27.0.0</AssemblyVersion>
+    <Version>4.28.0-alpha.1</Version>
+    <AssemblyVersion>4.28.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>
     <Description>

--- a/src/Altinn.App.PlatformServices.Tests/Options/NullInstanceAppOptionsProviderTests.cs
+++ b/src/Altinn.App.PlatformServices.Tests/Options/NullInstanceAppOptionsProviderTests.cs
@@ -15,7 +15,7 @@ namespace Altinn.App.PlatformServices.Tests.Options
             var provider = new NullInstanceAppOptionsProvider();
 
             provider.Id.Should().Be(string.Empty);
-            provider.GetInstanceAppOptionsAsync(new InstanceIdentifier(12345, Guid.NewGuid()), "nb", new Dictionary<string, string>()).Result.Options.Should().HaveCount(0);
+            provider.GetInstanceAppOptionsAsync(new InstanceIdentifier(12345, Guid.NewGuid()), "nb", new Dictionary<string, string>()).Result.Options.Should().BeNull();
         }
     }
 }

--- a/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.27.0-alpha.1</Version>
-    <AssemblyVersion>4.27.0.0</AssemblyVersion>
+    <Version>4.28.0-alpha.1</Version>
+    <AssemblyVersion>4.28.0.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>
     <Description>

--- a/src/Altinn.App.PlatformServices/Options/NullInstanceAppOptionsProvider.cs
+++ b/src/Altinn.App.PlatformServices/Options/NullInstanceAppOptionsProvider.cs
@@ -7,6 +7,8 @@ namespace Altinn.App.PlatformServices.Options
 {
     /// <summary>
     /// Nullobject for cases where there is no match on the requested <see cref="IInstanceAppOptionsProvider"/>
+    /// Options is set to null and not an empty list for the controller to be able to differensiate
+    /// between option provider found, but with no values and no option provider found ie. returns 404.
     /// </summary>
     public class NullInstanceAppOptionsProvider : IInstanceAppOptionsProvider
     {
@@ -16,7 +18,7 @@ namespace Altinn.App.PlatformServices.Options
         /// <inheritdoc/>
         public Task<AppOptions> GetInstanceAppOptionsAsync(InstanceIdentifier instanceIdentifier, string language, Dictionary<string, string> keyValuePairs)
         {
-            return Task.FromResult<AppOptions>(new AppOptions() { IsCacheable = false, Options = new List<AppOption>() });
+            return Task.FromResult<AppOptions>(new AppOptions() { IsCacheable = false, Options = null });
         }
     }
 }

--- a/src/App.IntegrationTests/ApiTests/OptionsApiTests.cs
+++ b/src/App.IntegrationTests/ApiTests/OptionsApiTests.cs
@@ -34,7 +34,7 @@ namespace App.IntegrationTestsRef.ApiTests
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
             
-            Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             List<AppOption> options = JsonConvert.DeserializeObject<List<AppOption>>(responseContent);
             Assert.Equal(7, options.Count);
         }
@@ -50,13 +50,13 @@ namespace App.IntegrationTestsRef.ApiTests
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
 
-            Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             List<AppOption> options = JsonConvert.DeserializeObject<List<AppOption>>(responseContent);
             Assert.Equal(5, options.Count);
         }
 
         [Fact]
-        public async Task InstanceAwareOptions_Returns404WhenNoneIsFound()
+        public async Task InstanceAwareOptions_Returns404WhenNoOptionProviderIsFound()
         {
             string token = PrincipalUtil.GetToken(1337);
             HttpClient client = SetupUtil.GetTestClient(_factory, "tdd", "endring-av-navn");
@@ -65,7 +65,7 @@ namespace App.IntegrationTestsRef.ApiTests
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
-            Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);            
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace App.IntegrationTestsRef.ApiTests
 
             HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
-            Assert.Equal(System.Net.HttpStatusCode.Forbidden, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [Fact]


### PR DESCRIPTION
This changes how options are returned when there are no elements in the list. Previously we returned 404 both when we could not find the specified option id and if the specified option id had zero elements. With this change we only return 404 if we can't find the specified option id. For the case of zero elements we just return an empty list. 