### PR TITLE
Add SSN to platformUser in instanceEvents

### DIFF
--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.31.1-alpha</Version>
+    <Version>4.31.1</Version>
     <AssemblyVersion>4.31.1.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Common.PEP" Version="1.0.39" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.7.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.29.0-alpha.1</Version>
-    <AssemblyVersion>4.29.0.0</AssemblyVersion>
+    <Version>4.30.0-alpha</Version>
+    <AssemblyVersion>4.30.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>
     <Description>
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Common.PEP" Version="1.0.39" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.6.2" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.31.0-alpha</Version>
-    <AssemblyVersion>4.31.0.0</AssemblyVersion>
+    <Version>4.31.1-alpha</Version>
+    <AssemblyVersion>4.31.1.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>
     <Description>

--- a/src/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.31.0-alpha</Version>
-    <AssemblyVersion>4.31.0.0</AssemblyVersion>
+    <Version>4.31.1-alpha</Version>
+    <AssemblyVersion>4.31.1.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>
     <Description>

--- a/src/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.29.0-alpha.1</Version>
-    <AssemblyVersion>4.29.0.0</AssemblyVersion>
+    <Version>4.30.0-alpha</Version>
+    <AssemblyVersion>4.30.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>
     <Description>

--- a/src/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.31.1-alpha</Version>
+    <Version>4.31.1</Version>
     <AssemblyVersion>4.31.1.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.6.2" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.8.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.31.1-alpha</Version>
+    <Version>4.31.1</Version>
     <AssemblyVersion>4.31.1.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>
@@ -31,7 +31,7 @@
     <PackageReference Include="Altinn.Common.PEP" Version="1.0.39" />
     <PackageReference Include="Altinn.Common.EFormidlingClient" Version="1.1.2" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.1.1" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.7.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.8.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.40" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.4.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />

--- a/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.29.0-alpha.1</Version>
-    <AssemblyVersion>4.29.0.0</AssemblyVersion>
+    <Version>4.30.0-alpha</Version>
+    <AssemblyVersion>4.30.0.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>
     <Description>
@@ -31,12 +31,13 @@
     <PackageReference Include="Altinn.Common.PEP" Version="1.0.39" />
     <PackageReference Include="Altinn.Common.EFormidlingClient" Version="1.1.2" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.1.1" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.6.2" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.7.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.40" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.4.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.11.0" />
+    <PackageReference Include="Scrutor" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.31.0-alpha</Version>
-    <AssemblyVersion>4.31.0.0</AssemblyVersion>
+    <Version>4.31.1-alpha</Version>
+    <AssemblyVersion>4.31.1.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>
     <Description>

--- a/src/Altinn.App.PlatformServices/Configuration/CacheSettings.cs
+++ b/src/Altinn.App.PlatformServices/Configuration/CacheSettings.cs
@@ -1,0 +1,13 @@
+﻿namespace Altinn.App.Services.Configuration
+{
+    /// <summary>
+    /// Represents caching settings used by the platform services
+    /// </summary>
+    public class CacheSettings
+    {
+        /// <summary>
+        /// The number of seconds the user profile will be kept in the cache
+        /// </summary>
+        public int ProfileCacheLifetimeSeconds { get; set; } = 540;
+    }
+}

--- a/src/Altinn.App.PlatformServices/Decorators/ProfileClientCachingDecorator.cs
+++ b/src/Altinn.App.PlatformServices/Decorators/ProfileClientCachingDecorator.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Altinn.App.Services.Configuration;
+using Altinn.App.Services.Interface;
+using Altinn.Platform.Profile.Models;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Altinn.App.Services.Decorators
+{
+    /// <summary>.
+    /// Decorates an implementation of IProfile by caching the party object.
+    /// If available, object is retrieved from cache without calling the service
+    /// </summary>
+    public class ProfileClientCachingDecorator : IProfile
+    {
+        private readonly IProfile _decoratedService;
+        private readonly IMemoryCache _memoryCache;
+        private readonly MemoryCacheEntryOptions _cacheOptions;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProfileClientCachingDecorator"/> class.
+        /// </summary>
+        public ProfileClientCachingDecorator(IProfile decoratedService, IMemoryCache memoryCache, IOptions<CacheSettings> _settings)
+        {
+            _decoratedService = decoratedService;
+            _memoryCache = memoryCache;
+
+            _cacheOptions = new()
+            {
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(_settings.Value.ProfileCacheLifetimeSeconds)
+            };
+        }
+
+        /// <inheritdoc/>
+        public async Task<UserProfile> GetUserProfile(int userId)
+        {
+            string uniqueCacheKey = "User_UserId_" + userId;
+
+            if (_memoryCache.TryGetValue(uniqueCacheKey, out UserProfile user))
+            {
+                return user;
+            }
+
+            user = await _decoratedService.GetUserProfile(userId);
+
+            if (user != null)
+            {
+                _memoryCache.Set(uniqueCacheKey, user, _cacheOptions);
+            }
+
+            return user;
+        }
+    }
+}

--- a/src/Altinn.App.PlatformServices/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Altinn.App.PlatformServices/Extensions/ClaimsPrincipalExtensions.cs
@@ -102,7 +102,7 @@ namespace Altinn.App.PlatformServices.Extensions
         /// </summary>
         public static int? GetPartyIdAsInt(this ClaimsPrincipal user)
         {
-            if (user.HasClaim(c => c.Type == AltinnCoreClaimTypes.UserId))
+            if (user.HasClaim(c => c.Type == AltinnCoreClaimTypes.PartyID))
             {
                 Claim partyIdClaim = user.FindFirst(c => c.Type == AltinnCoreClaimTypes.PartyID);
                 if (partyIdClaim != null && int.TryParse(partyIdClaim.Value, out int partyId))

--- a/src/Altinn.App.PlatformServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.PlatformServices/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Altinn.App.PlatformServices.Interface;
 using Altinn.App.PlatformServices.Options;
 using Altinn.App.Services;
 using Altinn.App.Services.Configuration;
+using Altinn.App.Services.Decorators;
 using Altinn.App.Services.Implementation;
 using Altinn.App.Services.Interface;
 using Altinn.Common.AccessTokenClient.Configuration;
@@ -42,6 +43,7 @@ namespace Altinn.App.PlatformServices.Extensions
             services.Configure<AppSettings>(configuration.GetSection("AppSettings"));
             services.Configure<GeneralSettings>(configuration.GetSection("GeneralSettings"));
             services.Configure<PlatformSettings>(configuration.GetSection("PlatformSettings"));
+            services.Configure<CacheSettings>(configuration.GetSection("CacheSettings"));
 
             services.AddHttpClient<IApplication, ApplicationClient>();
             services.AddHttpClient<IAuthentication, AuthenticationClient>();
@@ -54,6 +56,7 @@ namespace Altinn.App.PlatformServices.Extensions
             services.AddHttpClient<IEvents, EventsClient>();
             services.AddHttpClient<IPDF, PDFClient>();
             services.AddHttpClient<IProfile, ProfileClient>();
+            services.Decorate<IProfile, ProfileClientCachingDecorator>();
             services.AddHttpClient<IRegister, RegisterClient>();
             services.AddHttpClient<IText, TextClient>();
             services.AddHttpClient<IProcess, ProcessAppSI>();

--- a/src/Altinn.App.PlatformServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.PlatformServices/Extensions/ServiceCollectionExtensions.cs
@@ -7,11 +7,8 @@ using Altinn.App.PlatformServices.Interface;
 using Altinn.App.PlatformServices.Options;
 using Altinn.App.Services;
 using Altinn.App.Services.Configuration;
-<<<<<<< HEAD
 using Altinn.App.Services.Decorators;
-=======
 using Altinn.App.Services.Filters;
->>>>>>> main
 using Altinn.App.Services.Implementation;
 using Altinn.App.Services.Interface;
 using Altinn.Common.AccessTokenClient.Configuration;
@@ -78,7 +75,7 @@ namespace Altinn.App.PlatformServices.Extensions
         /// <param name="env">A reference to the current <see cref="IWebHostEnvironment"/> object.</param>
         public static void AddAppServices(this IServiceCollection services, IConfiguration configuration, IWebHostEnvironment env)
         {
-            // Services for Altinn App 
+            // Services for Altinn App
             services.AddTransient<IPDP, PDPAppSI>();
             services.AddTransient<IValidation, ValidationAppSI>();
             services.AddTransient<IPrefill, PrefillSI>();

--- a/src/App.IntegrationTests/DecoratorTests/ProfileTestCachingDecoratorTest.cs
+++ b/src/App.IntegrationTests/DecoratorTests/ProfileTestCachingDecoratorTest.cs
@@ -1,0 +1,101 @@
+﻿using System.Threading.Tasks;
+
+using Altinn.App.Services.Configuration;
+using Altinn.App.Services.Decorators;
+using Altinn.App.Services.Interface;
+using Altinn.Platform.Profile.Models;
+
+using App.IntegrationTests.Utils;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+using Xunit;
+
+namespace App.IntegrationTestsRef.DecoratorTests
+{
+    public class ProfileTestCachingDecoratorTest
+    {
+        private readonly Mock<IProfile> _decoratedServiceMock = new();
+        private readonly Mock<IOptions<CacheSettings>> cacheSettingsOptions;
+
+        public ProfileTestCachingDecoratorTest()
+        {
+            cacheSettingsOptions = new Mock<IOptions<CacheSettings>>();
+            cacheSettingsOptions.Setup(s => s.Value).Returns(new CacheSettings { ProfileCacheLifetimeSeconds = 540 });
+        }
+
+        /// <summary>
+        /// Tests that the userprofile available in the cache is returned to the caller without forwarding request to decorated service.
+        /// </summary>
+        [Fact]
+        public async Task GetUserProfileUserId_UserInCache_decoratedServiceNotCalled()
+        {
+            // Arrange
+            const int UserId = 12345;
+            MemoryCache memoryCache = new(new MemoryCacheOptions());
+
+            var userProfile = TestDataUtil.GetProfile(UserId);
+            memoryCache.Set("User_UserId_12345", userProfile);
+            var target = new ProfileClientCachingDecorator(_decoratedServiceMock.Object, memoryCache, cacheSettingsOptions.Object);
+
+            // Act
+            UserProfile actual = await target.GetUserProfile(UserId);
+
+            // Assert
+            _decoratedServiceMock.Verify(service => service.GetUserProfile(It.IsAny<int>()), Times.Never());
+            Assert.NotNull(actual);
+            Assert.Equal(UserId, actual.UserId);
+        }
+
+        /// <summary>
+        /// Tests that the userprofile available in the cache is returned to the caller without forwarding request to decorated service.
+        /// </summary>
+        [Fact]
+        public async Task GetUserProfileUserId_UserNotInCache_decoratedServiceCalledMockPopulated()
+        {
+            // Arrange
+            const int UserId = 12345;
+            MemoryCache memoryCache = new(new MemoryCacheOptions());
+
+            var userProfile = TestDataUtil.GetProfile(UserId);
+            _decoratedServiceMock.Setup(service => service.GetUserProfile(It.IsAny<int>())).ReturnsAsync(userProfile);
+            var target = new ProfileClientCachingDecorator(_decoratedServiceMock.Object, memoryCache, cacheSettingsOptions.Object);
+
+            // Act
+            UserProfile actual = await target.GetUserProfile(UserId);
+
+            // Assert
+            _decoratedServiceMock.Verify(service => service.GetUserProfile(It.IsAny<int>()), Times.Once());
+
+            Assert.NotNull(actual);
+            Assert.Equal(UserId, actual.UserId);
+            Assert.True(memoryCache.TryGetValue("User_UserId_12345", out UserProfile _));
+        }
+
+        /// <summary>
+        /// Tests that if the result from decorated service is null, nothing is stored in cache and the null object returned to caller.
+        /// </summary>
+        [Fact]
+        public async Task GetUserProfileUserUserId_NullFromDecoratedService_CacheNotPopulated()
+        {
+            // Arrange
+            const int UserId = 12345;
+            MemoryCache memoryCache = new(new MemoryCacheOptions());
+
+            _decoratedServiceMock.Setup(service => service.GetUserProfile(It.IsAny<int>())).ReturnsAsync((UserProfile)null);
+            var target = new ProfileClientCachingDecorator(_decoratedServiceMock.Object, memoryCache, cacheSettingsOptions.Object);
+
+            // Act
+            UserProfile actual = await target.GetUserProfile(UserId);
+
+            // Assert
+            _decoratedServiceMock.Verify(service => service.GetUserProfile(It.IsAny<int>()), Times.Once());
+            Assert.Null(actual);
+            Assert.False(memoryCache.TryGetValue("User_UserId_12345", out UserProfile _));
+        }
+
+    }
+}

--- a/src/App.IntegrationTests/DecoratorTests/ProfileTestCachingDecoratorTest.cs
+++ b/src/App.IntegrationTests/DecoratorTests/ProfileTestCachingDecoratorTest.cs
@@ -96,6 +96,5 @@ namespace App.IntegrationTestsRef.DecoratorTests
             Assert.Null(actual);
             Assert.False(memoryCache.TryGetValue("User_UserId_12345", out UserProfile _));
         }
-
     }
 }

--- a/src/App.IntegrationTests/Utils/TestDataUtil.cs
+++ b/src/App.IntegrationTests/Utils/TestDataUtil.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
+using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Storage.Interface.Models;
 
 using App.IntegrationTests.Mocks.Services;
@@ -12,7 +14,10 @@ namespace App.IntegrationTests.Utils
     {
         private static JsonSerializerOptions serializerOptions = new JsonSerializerOptions
         {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
         };
 
         public static void PrepareInstance(string org, string app, int instanceOwnerId, Guid instanceGuid)
@@ -137,6 +142,26 @@ namespace App.IntegrationTests.Utils
             }
 
             return null;
+        }
+
+        public static UserProfile GetProfile(int userId)
+        {
+            string path = GetUserProfilePath(userId);
+
+            if (File.Exists(path))
+            {
+                string content = File.ReadAllText(path);
+                UserProfile profile = JsonSerializer.Deserialize<UserProfile>(content, serializerOptions);
+                return profile;
+            }
+
+            return null;
+        }
+
+        private static string GetUserProfilePath(int userId)
+        {
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(InstanceMockSI).Assembly.Location).LocalPath);
+            return Path.Combine(unitTestFolder, @"..\..\..\Data\Profile\User\", userId + @".json");
         }
 
         private static string GetApplicationPath(string org, string app)


### PR DESCRIPTION
For each generated instance event a lookup is done to find the SSN of the user that triggered the event, and this data is added to the instanceEvent. 

Added caching of userprofile. 


Tips on how to best verify that SSN is  included is appreciated. No obvious way as I see it, except checking incomming events and validating towards userprofile in testdata.
#5751