### PR TITLE
Expose prefill method to user

### DIFF
--- a/src/Altinn.App.PlatformServices/Implementation/PrefillSI.cs
+++ b/src/Altinn.App.PlatformServices/Implementation/PrefillSI.cs
@@ -53,12 +53,18 @@ namespace Altinn.App.Services.Implementation
         }
 
         /// <inheritdoc/>
+        public void PrefillDataModel(object dataModel, Dictionary<string, string> externalPrefill, bool continueOnError = false)
+        {
+            LoopThroughDictionaryAndAssignValuesToDataModel(externalPrefill, null, dataModel, continueOnError);
+        }
+
+        /// <inheritdoc/>
         public async Task PrefillDataModel(string partyId, string dataModelName, object dataModel, Dictionary<string, string> externalPrefill)
         {
             // Prefill from external input. Only available during instansiation
             if (externalPrefill != null && externalPrefill.Count > 0)
             {
-                LoopThroughDictionaryAndAssignValuesToDataModel(externalPrefill, null, dataModel, true);
+                PrefillDataModel(dataModel, externalPrefill, true);
             }
 
             string jsonConfig = _appResourcesService.GetPrefillJson(dataModelName);

--- a/src/Altinn.App.PlatformServices/Interface/IPrefill.cs
+++ b/src/Altinn.App.PlatformServices/Interface/IPrefill.cs
@@ -9,6 +9,14 @@ namespace Altinn.App.Services.Interface
     public interface IPrefill
     {
         /// <summary>
+        /// Prefills the data model based on key/values in the dictionary.
+        /// </summary>
+        /// <param name="dataModel">The data model object</param>
+        /// <param name="externalPrefill">External given prefill</param>
+        /// <param name="continueOnError">Ignore errors when true, throw on errors when false</param>
+        void PrefillDataModel(object dataModel, Dictionary<string, string> externalPrefill, bool continueOnError = false);
+
+        /// <summary>
         /// Prefills the data model based on the prefill json configuration file
         /// </summary>
         /// <param name="partyId">The partyId of the instance owner</param>


### PR DESCRIPTION
# Expose prefill method to user

Writing prefill code is tedious and error-prone (as the tree might have
been partially constructed). Exposing the inner functionality of
PrefillSI, we can use the same key/value pairs as is used in the prefill
json.

E.g.
```csharp
   public async Task DataCreation(Instance instance, object data, Dictionary<string, string> prefill) {
       prefillService.PrefillDataModel(data, new Dictionary<string, string> {
           { "a.value", "a" },
           { "b.value", "b" },
           // ..
       });
       await Task.CompletedTask;
   }
```

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
- [ ] Changelog is updated with a separate linked PR 
  - [ ] [altinn-app-frontend](https://docs.altinn.studio/community/changelog/app-frontend/)- (if applicable)
  - [ ] [nuget-packages](https://docs.altinn.studio/community/changelog/app-nuget/) - (if applicable)
