### PR TITLE
Add base64 encoding to lastname parameter

### DIFF
--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.29.0-alpha.1</Version>
+    <Version>4.29.0-alpha.2</Version>
     <AssemblyVersion>4.29.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>

--- a/src/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.29.0-alpha.1</Version>
+    <Version>4.29.0-alpha.2</Version>
     <AssemblyVersion>4.29.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>

--- a/src/Altinn.App.PlatformServices.Tests/Implementation/PersonClientTests.cs
+++ b/src/Altinn.App.PlatformServices.Tests/Implementation/PersonClientTests.cs
@@ -168,7 +168,7 @@ namespace Altinn.App.PlatformServices.Tests.Implementation
             return await Task.FromResult(new HttpResponseMessage { Content = stringContent });
         }
 
-        private string ConvertToBase64(string text)
+        private static string ConvertToBase64(string text)
         {
             var bytes = Encoding.UTF8.GetBytes(text);
             return Convert.ToBase64String(bytes);

--- a/src/Altinn.App.PlatformServices.Tests/Implementation/PersonClientTests.cs
+++ b/src/Altinn.App.PlatformServices.Tests/Implementation/PersonClientTests.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -89,7 +90,7 @@ namespace Altinn.App.PlatformServices.Tests.Implementation
             Assert.StartsWith("http://real.domain.com", platformRequest!.RequestUri!.ToString());
             Assert.EndsWith("persons", platformRequest!.RequestUri!.ToString());
             Assert.Equal("personnummer", platformRequest!.Headers.GetValues("X-Ai-NationalIdentityNumber").First());
-            Assert.Equal("lastname", platformRequest!.Headers.GetValues("X-Ai-LastName").First());
+            Assert.Equal(ConvertToBase64("lastname"), platformRequest!.Headers.GetValues("X-Ai-LastName").First());
 
             Assert.NotNull(actual);
         }
@@ -165,6 +166,12 @@ namespace Altinn.App.PlatformServices.Tests.Implementation
             string content = JsonSerializer.Serialize(obj);
             StringContent stringContent = new StringContent(content, Encoding.UTF8, "application/json");
             return await Task.FromResult(new HttpResponseMessage { Content = stringContent });
+        }
+
+        private string ConvertToBase64(string text)
+        {
+            var bytes = Encoding.UTF8.GetBytes(text);
+            return Convert.ToBase64String(bytes);
         }
     }
 }

--- a/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>4.29.0-alpha.1</Version>
+    <Version>4.29.0-alpha.2</Version>
     <AssemblyVersion>4.29.0.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>

--- a/src/Altinn.App.PlatformServices/Implementation/PersonClient.cs
+++ b/src/Altinn.App.PlatformServices/Implementation/PersonClient.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -75,7 +76,7 @@ namespace Altinn.App.PlatformServices.Implementation
             AddAuthHeaders(request);
 
             request.Headers.Add("X-Ai-NationalIdentityNumber", nationalIdentityNumber);
-            request.Headers.Add("X-Ai-LastName", lastName);
+            request.Headers.Add("X-Ai-LastName", ConvertToBase64(lastName));
 
             var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct);
 
@@ -106,6 +107,12 @@ namespace Altinn.App.PlatformServices.Implementation
             }
 
             throw await PlatformHttpException.CreateAsync(response);
+        }
+
+        private string ConvertToBase64(string text)
+        {
+            var bytes = Encoding.UTF8.GetBytes(text);
+            return Convert.ToBase64String(bytes);
         }
     }
 }

--- a/src/Altinn.App.PlatformServices/Implementation/PersonClient.cs
+++ b/src/Altinn.App.PlatformServices/Implementation/PersonClient.cs
@@ -109,7 +109,7 @@ namespace Altinn.App.PlatformServices.Implementation
             throw await PlatformHttpException.CreateAsync(response);
         }
 
-        private string ConvertToBase64(string text)
+        private static string ConvertToBase64(string text)
         {
             var bytes = Encoding.UTF8.GetBytes(text);
             return Convert.ToBase64String(bytes);


### PR DESCRIPTION
Request header values are limited to ASCII characters. Values must be encoded with base64.