### PR TITLE
Log exceptions as data instead of string

### DIFF
--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -337,7 +337,7 @@ namespace Altinn.App.Api.Controllers
 
         private ActionResult ExceptionResponse(Exception exception, string message)
         {
-            _logger.LogError($"{message}: {exception}");
+            _logger.LogError(exception, message);
 
             if (exception is PlatformHttpException)
             {

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -722,7 +722,7 @@ namespace Altinn.App.Api.Controllers
 
         private ActionResult ExceptionResponse(Exception exception, string message)
         {
-            _logger.LogError($"{message}: {exception}");
+            _logger.LogError(exception, message);
 
             if (exception is PlatformHttpException platformHttpException)
             {

--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -468,7 +468,7 @@ namespace Altinn.App.Api.Controllers
 
         private ActionResult ExceptionResponse(Exception exception, string message)
         {
-            _logger.LogError($"{message}: {exception}");
+            _logger.LogError(exception, message);
 
             if (exception is PlatformHttpException)
             {


### PR DESCRIPTION
`LogError` as a special method to log exceptions that is used in many other locations of the project, and should probably be used here as well.