### PR TITLE
Handle null in lastChangedBy

### DIFF
--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -699,7 +699,7 @@ namespace Altinn.App.Api.Controllers
                 return Ok(new List<SimpleInstance>());
             }
 
-            List<string> userAndOrgIds = activeInstances.Select(i => i.LastChangedBy).Distinct().ToList();
+            List<string> userAndOrgIds = activeInstances.Where(i => !string.IsNullOrWhiteSpace(i.LastChangedBy)).Select(i => i.LastChangedBy).Distinct().ToList();
 
             Dictionary<string, string> userAndOrgLookup = new Dictionary<string, string>();
 

--- a/src/Altinn.App.Api/Mappers/SimpleInstanceMapper.cs
+++ b/src/Altinn.App.Api/Mappers/SimpleInstanceMapper.cs
@@ -36,7 +36,7 @@ namespace Altinn.App.Api.Mappers
             List<SimpleInstance> simpleInstances = new List<SimpleInstance>();
             foreach (Instance instance in instances)
             {
-                string lastChangedByName = userDictionary.ContainsKey(instance.LastChangedBy) ? userDictionary[instance.LastChangedBy] : string.Empty;
+                string lastChangedByName = userDictionary.ContainsKey(instance.LastChangedBy ?? string.Empty) ? userDictionary[instance.LastChangedBy] : string.Empty;
                 simpleInstances.Add(MapInstanceToSimpleInstance(instance, lastChangedByName));
             }
 

--- a/src/App.IntegrationTests/ApiTests/InstanceApiTest.cs
+++ b/src/App.IntegrationTests/ApiTests/InstanceApiTest.cs
@@ -1202,16 +1202,20 @@ namespace App.IntegrationTests.ApiTests
 
             _output.WriteLine(json);
             List<SimpleInstance> activeInstances = System.Text.Json.JsonSerializer.Deserialize<List<SimpleInstance>>(json, options);
-            SimpleInstance actual = activeInstances.First();
+            SimpleInstance normal = activeInstances.First(i => i.Id == "1401/447ed22d-67a8-42c7-8add-cc35eba304f2");
+            SimpleInstance noLastCangedBy = activeInstances.First(i => i.Id == "1401/8d5a293f-98ed-4c2c-9a6b-3593f49b4d26");
 
             // Assert
             string expectedLastChangedBy = "DDG Fitness";
-            DateTime expectedLastChanged = new DateTime(637679891830000000);
+            DateTime expectedLastChanged = DateTime.Parse("2021-09-23T10:19:43");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Single(activeInstances);
-            Assert.Equal(expectedLastChanged, actual.LastChanged);
-            Assert.Equal(expectedLastChangedBy, actual.LastChangedBy);
+            Assert.Equal(2, activeInstances.Count);
+            Assert.Equal(expectedLastChanged, normal.LastChanged);
+            Assert.Equal(expectedLastChangedBy, normal.LastChangedBy);
+
+            // Seccond instance has empty lastChangedBy
+            Assert.Empty(noLastCangedBy.LastChangedBy);
         }
     }
 }

--- a/src/App.IntegrationTests/Data/Instances/ttd/presentationfields-app/1401/8d5a293f-98ed-4c2c-9a6b-3593f49b4d26.json
+++ b/src/App.IntegrationTests/Data/Instances/ttd/presentationfields-app/1401/8d5a293f-98ed-4c2c-9a6b-3593f49b4d26.json
@@ -1,0 +1,40 @@
+{
+  "id": "1401/8d5a293f-98ed-4c2c-9a6b-3593f49b4d26",
+  "instanceOwner": {
+    "partyId": "1401",
+    "personNumber": "14015678901"
+  },
+  "appId": "ttd/presentationfields-app",
+  "org": "ttd",
+  "process": {
+    "started": "2019-12-11T09:34:35.5471442Z",
+    "startEvent": "StartEvent_1",
+    "currentTask": {
+      "flow": 2,
+      "started": "2019-12-11T09:34:37.6872728Z",
+      "elementId": "Task_1",
+      "name": "Utfylling",
+      "altinnTaskType": "data"
+    }
+  },
+  "status": {
+    "isArchived": false,
+    "isSoftDeleted": false,
+    "isHardDeleted": false,
+    "readStatus": "Read"
+  },
+  "lastChangedBy": null,
+  "lastChanged": "2021-09-23T10:19:43",
+  "presentationTexts": {
+    "Title": "Sophie Salt"
+  },
+  "data": [
+    {
+      "id": "590ebc27-246e-4a0a-aea3-4296cb231d78",
+      "dataType": "default",
+      "contentType": "application/xml",
+      "size": 0,
+      "locked": false
+    }
+  ]
+}


### PR DESCRIPTION
This caused a null pointer exception in `/{org}/{app}/instances/{instanceOwnerPartyId}/active`
when the instance was initialized from api.