### PR TITLE
fix: style tag is not a valid child of body

### DIFF
--- a/src/App/views/Home/Index.cshtml
+++ b/src/App/views/Home/Index.cshtml
@@ -21,13 +21,13 @@
   <!-- Runtime CSS -->
   <link rel="stylesheet" type="text/css" href="https://altinncdn.no/toolkits/altinn-app-frontend/3/altinn-app-frontend.css">
 
-</head>
-<body>
   <style>
     html, body {
       height: 100%;
     }
   </style>
+</head>
+<body>
   <div class="flex-column d-flex media-body">
 
     <script>


### PR DESCRIPTION
The `style` tag is not valid as a direct child of `body` as [per the spec](https://html.spec.whatwg.org/multipage/semantics.html#the-style-element).
