### PR TITLE
Use long options in Dockerfile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -5,8 +5,8 @@ COPY /App ./App
 
 WORKDIR /App
 
-RUN dotnet build App.csproj -c Release -o /app_output
-RUN dotnet publish App.csproj -c Release -o /app_output
+RUN dotnet build App.csproj --configuration Release --output /app_output
+RUN dotnet publish App.csproj --configuration Release --output /app_output
 
 FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine AS final
 EXPOSE 5005
@@ -14,7 +14,14 @@ WORKDIR /app
 COPY --from=build /app_output .
 
 # setup the user and group
+# busybox doesn't include longopts, so the options are roughly
+# -g --gid
+# -u --uid
+# -G --group
+# -D --disable-password
+# -s --shell
 RUN addgroup -g 3000 dotnet && adduser -u 1000 -G dotnet -D -s /bin/false dotnet
+
 USER dotnet
 RUN mkdir /tmp/logtelemetry
 


### PR DESCRIPTION
Short options are good for interactive scripts, but long options are
better in scripts.