### PR TITLE
Fixing deep fs recursion issue

### DIFF
--- a/src/Altinn.App.PlatformServices/Extensions/ConfigurationBuilderExtensions.cs
+++ b/src/Altinn.App.PlatformServices/Extensions/ConfigurationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
 
@@ -15,11 +16,21 @@ namespace Altinn.App.PlatformServices.Extensions
         /// <param name="args">The original command line arguments</param>
         public static void LoadAppConfig(this IConfigurationBuilder builder, string[] args = null)
         {
-            builder.AddJsonFile(
-                new PhysicalFileProvider("/"),
-                @"altinn-appsettings-secret/altinn-appsettings-secret.json",
-                true,
-                true);
+            try
+            {
+                builder.AddJsonFile(
+                    new PhysicalFileProvider("/altinn-appsettings-secret"),
+                    @"altinn-appsettings-secret.json",
+                    true,
+                    true);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // Extra secrets configuration file is optional. The directory usually does not exist, but might
+                // typically be mounted to a folder directly on the filesystem root. We could init the file provider
+                // with the root folder (and not have to catch this exception), but that would cause
+                // 'reloadOnChange: true' to recurse through the entire file system to monitor for changes.
+            }
 
             // Add values from environment and command line arguments last, to override values from other sources.
             builder.AddEnvironmentVariables();

--- a/src/Altinn.App.PlatformServices/Extensions/ConfigurationBuilderExtensions.cs
+++ b/src/Altinn.App.PlatformServices/Extensions/ConfigurationBuilderExtensions.cs
@@ -26,8 +26,8 @@ namespace Altinn.App.PlatformServices.Extensions
             }
             catch (DirectoryNotFoundException)
             {
-                // Extra secrets configuration file is optional. The directory usually does not exist, but might
-                // typically be mounted to a folder directly on the filesystem root. We could init the file provider
+                // Extra secrets configuration file is optional. The directory does not exist in dev environments, but
+                // is otherwise mounted to a folder directly on the filesystem root. We could init the file provider
                 // with the root folder (and not have to catch this exception), but that would cause
                 // 'reloadOnChange: true' to recurse through the entire file system to monitor for changes.
             }


### PR DESCRIPTION
When starting an app with `dotnet run` on my linux host, I got a `System.IO.IOException: Invalid argument` caused by this code starting a recursive file system watch over the whole root filesystem.

After a discussion on slack yesterday, this looked like the best solution, where we'll watch a sub-folder on the root filesystem instead.

Tested with and without this folder and configuration file in place, against a test app, using the release/v4 branch.