### PR TITLE
Bugfix/allow any content type when unspecified

### DIFF
--- a/src/Altinn.App.Common/RequestHandling/RequestPartValidator.cs
+++ b/src/Altinn.App.Common/RequestHandling/RequestPartValidator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -62,8 +62,9 @@ namespace Altinn.App.Common.RequestHandling
                 {
                     string contentTypeWithoutEncoding = part.ContentType.Split(";")[0];
 
-                    // TODO: Support for any content type?
-                    if (!dataType.AllowedContentTypes.Contains(contentTypeWithoutEncoding))
+                    if (dataType.AllowedContentTypes != null &&
+                        dataType.AllowedContentTypes.Count > 0 &&
+                        !dataType.AllowedContentTypes.Contains(contentTypeWithoutEncoding))
                     {
                         return $"The multipart section named {part.Name} has a Content-Type '{part.ContentType}' which is invalid for element type '{dataType.Id}'";
                     }

--- a/src/Altinn.App.Common/RequestHandling/RequestPartValidator.cs
+++ b/src/Altinn.App.Common/RequestHandling/RequestPartValidator.cs
@@ -62,7 +62,7 @@ namespace Altinn.App.Common.RequestHandling
                 {
                     string contentTypeWithoutEncoding = part.ContentType.Split(";")[0];
 
-                    // only restrict content type if allowedContentTypes is specified
+                    // restrict content type if allowedContentTypes is specified
                     if (dataType.AllowedContentTypes != null &&
                         dataType.AllowedContentTypes.Count > 0 &&
                         !dataType.AllowedContentTypes.Contains(contentTypeWithoutEncoding))

--- a/src/Altinn.App.Common/RequestHandling/RequestPartValidator.cs
+++ b/src/Altinn.App.Common/RequestHandling/RequestPartValidator.cs
@@ -62,6 +62,7 @@ namespace Altinn.App.Common.RequestHandling
                 {
                     string contentTypeWithoutEncoding = part.ContentType.Split(";")[0];
 
+                    // only restrict content type if allowedContentTypes is specified
                     if (dataType.AllowedContentTypes != null &&
                         dataType.AllowedContentTypes.Count > 0 &&
                         !dataType.AllowedContentTypes.Contains(contentTypeWithoutEncoding))


### PR DESCRIPTION
Handle case where allowed content types are null or empty for attachments in multipart request. 

This solution does not restrict content type when allowedContentTypes are not specified in applicationmetadata.json.
This is the same solution that is currently being used when uploading attachments manually as seen in the DataController in the CompliesWithDataRestrictions method on line 725. 