### PR TITLE
Support app metadata without onEntry property

### DIFF
--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>5.1.0-alpha.2</Version>
+    <Version>5.1.0-alpha.3</Version>
     <AssemblyVersion>5.1.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>

--- a/src/Altinn.App.Api/Controllers/HomeController.cs
+++ b/src/Altinn.App.Api/Controllers/HomeController.cs
@@ -104,8 +104,7 @@ namespace Altinn.App.Api.Controllers
             }
 
             Application application = _appResources.GetApplication();
-            bool stateless = !_onEntryWithInstance.Contains(application.OnEntry?.Show);
-            if (!stateless) 
+            if (!IsStatelessApp(application)) 
             {
                 return false;
             }
@@ -118,6 +117,16 @@ namespace Altinn.App.Api.Controllers
             }
 
             return false;
+        }
+
+        private bool IsStatelessApp(Application application)
+        {
+            if (application.OnEntry == null)
+            {
+                return false;
+            }
+
+            return !_onEntryWithInstance.Contains(application.OnEntry?.Show);
         }
 
         private DataType GetStatelessDataType(Application application)

--- a/src/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>5.1.0-alpha.2</Version>
+    <Version>5.1.0-alpha.3</Version>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>

--- a/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>5.1.0-alpha.2</Version>
+    <Version>5.1.0-alpha.3</Version>
     <AssemblyVersion>5.1.0.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>


### PR DESCRIPTION

Bugfix for changes made for https://github.com/Altinn/altinn-studio/issues/8403. 

When no `onEntry` property was defined in applicationMetadata, the check for stateless did not work as expected. 
