### PR TITLE
Add call to configBuilder.LoadAppConfig(); to initialize appsettings

### DIFF
--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -30,6 +30,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 ConfigureServices(builder.Services, builder.Configuration);
 
+ConfigureWebHost(builder.WebHost);
+
 var app = builder.Build();
 
 Configure();
@@ -119,6 +121,14 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     {
         c.SwaggerDoc("v1", new OpenApiInfo { Title = "Altinn App Api", Version = "v1" });
         IncludeXmlComments(c);
+    });
+}
+
+void ConfigureWebHost(IWebHostBuilder webHostBuilder)
+{
+    webHostBuilder.ConfigureAppConfiguration((_, configBuilder) =>
+    {
+        configBuilder.LoadAppConfig(args);
     });
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Version 6 of app-template did not call LoadAppCofig. Adds kall to this method to load appsettings if present

## Related Issue(s)
- #125 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
