### PR TITLE
Remove warning because of double specification of applicationUrl

### DIFF
--- a/src/App/Properties/launchSettings.json
+++ b/src/App/Properties/launchSettings.json
@@ -20,8 +20,7 @@
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:56227/"
+      }
     }
   }
 }

--- a/src/App/Properties/launchSettings.json
+++ b/src/App/Properties/launchSettings.json
@@ -20,7 +20,8 @@
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "applicationUrl": "http://*:5005"
     }
   }
 }

--- a/src/App/appsettings.json
+++ b/src/App/appsettings.json
@@ -1,11 +1,4 @@
 {
-  "Kestrel": {
-    "EndPoints": {
-      "Http": {
-        "Url": "http://*:5005"
-      }
-    }
-  },
   "AppSettings": {
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
     "RuntimeCookieName": "AltinnStudioRuntime",


### PR DESCRIPTION
On startup of apps, the following warning is displayed.
```
warn: Microsoft.AspNetCore.Server.Kestrel[0]
      Overriding address(es) 'http://localhost:56227/'. Binding to endpoints defined via IConfiguration and/or UseKestrel() instead.
```
This is caused by specifiying `"applicationUrl": "http://localhost:56227`  in launchSettings.json and 

```
"Kestrel": {
    "EndPoints": {
      "Http": {
        "Url": "http://*:5005"
      }
    }
  }
```
in appsettings.json

~~I propose to remove the wrong declaration in lanuchSettings.json~~

**Edit:**
After testing the docker container, I found that we should rather fix the `Url` in launchSettings.json and remove the `Url` in appsettings.json to remove this warning everywhere.