### PR TITLE
Add Kestrel section to appsettings and remove other URL settings

### DIFF
--- a/src/App/Properties/launchSettings.json
+++ b/src/App/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://*:5005"
+      "applicationUrl": "http://localhost:56227/"
     }
   }
 }

--- a/src/App/Properties/launchSettings.json
+++ b/src/App/Properties/launchSettings.json
@@ -20,8 +20,7 @@
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:56227/"
+      }
     }
   }
 }

--- a/src/App/appsettings.json
+++ b/src/App/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "Kestrel": {
+    "EndPoints": {
+      "Http": {
+        "Url": "http://*:5005"
+      }
+    }
+  },
   "AppSettings": {
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
     "RuntimeCookieName": "AltinnStudioRuntime",

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -12,6 +12,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS final
 EXPOSE 5005
 WORKDIR /app
 COPY --from=build /app_output .
+ENV ASPNETCORE_URLS=
 
 # setup the user and group
 # busybox doesn't include longopts, so the options are roughly


### PR DESCRIPTION
~~Reverts Altinn/app-template-dotnet#155~~

~~removing Kestrel section from appsettings.json results in applications trying to start on port 80 once deployed. 
Ports below 1024 are marked as privileged on linux and non-root users are not allowed to bind to these ports leading to application crash on startup~~

Add config in appsettings back and remove applicationUrl from launchSettings and remove value of ASPNETCORE_URLS in docker image to remove warning both locally and in docker

Fixes #163