### PR TITLE
Fix a few issues with the Dockerfile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,16 +1,16 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
-WORKDIR /
-
-COPY /App ./App
-
 WORKDIR /App
 
-RUN dotnet build App.csproj --configuration Release --output /app_output
+COPY /App/App.csproj .
+RUN dotnet restore App.csproj
+
+COPY /App .
+
 RUN dotnet publish App.csproj --configuration Release --output /app_output
 
 FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS final
 EXPOSE 5005
-WORKDIR /app
+WORKDIR /App
 COPY --from=build /app_output .
 ENV ASPNETCORE_URLS=
 


### PR DESCRIPTION
I'm opening this mainly because I want to give a heads up on these issues. I'm not in a hurry to have this merged, but it seems wasteful to not share the painful experience of figuring out this.

I tried to work on some sort of automated testing and ran into a really strange issue with dotnet in docker. The docker container did not work with `--env DOTNET_ENVIRONMENT=Development`. After lots of guesswork I found that deleting the `wwwroot` folder fixed the issue. It turns out that when you do a separate `build` step it generates `App.staticwebassets.runtime.json` with full absolute path to the `wwwroot` folder, and it gets included in the `publish` result. In the `build` step the path is `/App/wwwroot`, but in final the name was `/app/wwwroot`.

This fixes 3 issues
* A separate `restore` step makes for faster iteration when building repeatedly locally without downloading dependencies.
* Consistent folder name `app` vs `App` in build container vs final container
* A separate `dotnet build` step doesn't really make much sense, and the resulting `App.staticwebassets.runtime.json` is apparently just causing issues.

