### PR TITLE
Remove link to altinn-din from app-template

### DIFF
--- a/src/App/views/Home/Index.cshtml
+++ b/src/App/views/Home/Index.cshtml
@@ -15,9 +15,6 @@
   <link rel="stylesheet" href="https://altinncdn.no/toolkits/fortawesome/altinn-no-regular/0.1/css/embedded-woff.css">
   <link rel="stylesheet" href="https://altinncdn.no/toolkits/fortawesome/altinn-studio/0.1/css/embedded-woff.css">
 
-  <!-- Fonts -->
-  <link href="https://altinncdn.no/fonts/altinn-din/altinn-din.css" rel="stylesheet">
-
   <!-- Runtime CSS -->
   <link rel="stylesheet" type="text/css" href="https://altinncdn.no/toolkits/altinn-app-frontend/3/altinn-app-frontend.css">
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In the next release of app-frontend, the font is switched to use Inter, and this font is added directly through app-frontend's css bundle, so a link in app-template is not needed https://github.com/Altinn/app-frontend-react/pull/1173. Therefore, the link to Altinn-DIN should be removed since this will no longer be used.

## Related Issue(s)
Fixes #181 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
