### PR TITLE
Latest chart version as default

### DIFF
--- a/src/deployment/Chart.yaml
+++ b/src/deployment/Chart.yaml
@@ -7,4 +7,4 @@ version: 1.1.0
 dependencies:
 - name: deployment
   repository: https://charts.altinn.studio/
-  version: 2.8.0
+  version: 3.1.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New apps are deployed with a late version of the helm charts, it should use the newest version avaiable
