### PR TITLE
chore: bump app lib references to v8.3.5

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -5,10 +5,10 @@
     <RootNamespace>Altinn.App</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="8.0.0">
+    <PackageReference Include="Altinn.App.Api" Version="8.3.5">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Core" Version="8.0.0" />
+    <PackageReference Include="Altinn.App.Core" Version="8.3.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Bumped to latest version, 8.0.0 -> 8.3.5
Made no changes to default app config, as these are minor/patch upgrades and should not be breaking. 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] All tests run green
