### PR TITLE
Update Dockerfile to include timezone and culture information

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -23,6 +23,10 @@ ENV ASPNETCORE_URLS=
 # -s --shell
 RUN addgroup -g 3000 dotnet && adduser -u 1000 -G dotnet -D -s /bin/false dotnet
 
+# Add globalization timezone support
+RUN apk add --no-cache icu-libs tzdata
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+
 USER dotnet
 RUN mkdir /tmp/logtelemetry
 


### PR DESCRIPTION
 ```json
"PdfGeneratorSettings": {
    "DisplayFooter": true
}
```

requires globalisation and timezone info in docker images.

This will ensure that new apps gets this setting by default.

```dockerfile
# Add globalization timezone support
RUN apk add --no-cache icu-libs tzdata
ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
```

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/pull/792

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
