### PR TITLE
Update App.csproj

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -8,7 +8,6 @@
     <PackageReference Include="Altinn.App.Api" Version="8.3.7">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Core" Version="8.3.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>


### PR DESCRIPTION
## Description
This patch removes the reference to `Altinn.App.Core`, as this is automatically included as a dependency with the `Altinn.App.Api` package.

Removing this entry avoids developer confusion and makes manual version updates slightly easier 🙂

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
