### PR TITLE
Make CS4014 an error in app code

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -30,6 +30,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591;1998</NoWarn>
+    <WarningsAsErrors>CS4014</WarningsAsErrors>
   </PropertyGroup>
   <Target Name="CopyXMLFromPackagesForBuild" AfterTargets="Build">
     <ItemGroup>


### PR DESCRIPTION
I can't see a good reason when an app would intentionally not await a task, and suppressing the issue is very easy.

[CS4014](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs4014) Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the await operator to the result of the call.