### PR TITLE
Bump applib, cleanup dependencies

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -5,12 +5,10 @@
     <RootNamespace>Altinn.App</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="8.3.7">
+    <PackageReference Include="Altinn.App.Api" Version="8.6.2">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Core" Version="8.3.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Altinn.App.Core" Version="8.6.2" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\css\" />

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -5,10 +5,10 @@
     <RootNamespace>Altinn.App</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Altinn.App.Api" Version="8.6.2">
+    <PackageReference Include="Altinn.App.Api" Version="8.6.3">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*.xml</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Altinn.App.Core" Version="8.6.2" />
+    <PackageReference Include="Altinn.App.Core" Version="8.6.3" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\css\" />


### PR DESCRIPTION
## Description
* As of 8.6 should not have `Swashbuckle.AspNetCore`
* Why is `Microsoft.Extensions.Logging.Debug` there? It's not added 

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
