### PR TITLE
Remove '$id' property from model JSON schema

### DIFF
--- a/src/App/models/model.schema.json
+++ b/src/App/models/model.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "http://altinn-repositories:3000/bjosttveit/v4-data/App/models/model.schema.json",
   "type": "object",
   "info": {
     "rootNode": ""


### PR DESCRIPTION
## Description
Remove '$id' property from model JSON schema.
Noticed this while reviewing some unrelated code. AFAICT `$id` is not being read anywhere in the app (frontend or backend)

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
